### PR TITLE
Add initial pytest tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ license = {text = "MIT"}
 authors = [{name = "Your Name", email = "your@email.com"}]
 dependencies = ["colorama"]
 
+[project.optional-dependencies]
+dev = ["pytest"]
+
 [project.scripts]
 tempfile = "tempfile_cli.main:main"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import argparse
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from tempfile_cli.commands import new
+
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    new.register(subparsers)
+    return parser
+
+
+def test_new_argparse():
+    parser = make_parser()
+    args = parser.parse_args(["new", "example.txt", "--tag", "a", "--tag", "b"])
+    assert args.command == "new"
+    assert args.name == "example.txt"
+    assert args.tag == ["a", "b"]
+    assert args.handler == new.handle

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from tempfile_cli.core import utils
+
+
+def test_metadata_roundtrip(tmp_path, monkeypatch):
+    metadata_file = tmp_path / "metadata.json"
+    monkeypatch.setattr(utils, "METADATA_FILE", metadata_file)
+    data = {"foo": 1, "bar": {"baz": 2}}
+    utils.save_metadata(data)
+    loaded = utils.load_metadata()
+    assert loaded == data


### PR DESCRIPTION
## Summary
- add pytest tests for utils metadata round trip
- test argument parsing for `new` command
- list pytest as an optional dev dependency

## Testing
- `pytest -q`
