### PR TITLE
Add concise docs for command functions

### DIFF
--- a/tempfile_cli/commands/clean.py
+++ b/tempfile_cli/commands/clean.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from tempfile_cli.core.utils  import load_metadata, save_metadata, TEMPFILE_DIR, load_config
 
 def register(subparsers):
-    # Register the 'clean' subcommand
+    """Register the ``clean`` subcommand to remove old tempfiles."""
     parser = subparsers.add_parser("clean", help="Delete old tempfiles")
     default_days = int(load_config().get("default_days", 30))  # fallback = 30
     parser.add_argument("days", nargs="?", type=int, default=default_days,
@@ -10,6 +10,7 @@ def register(subparsers):
     parser.set_defaults(handler=handle)
 
 def handle(args):
+    """Delete tempfiles older than the specified number of days."""
     now = datetime.now()
     metadata = load_metadata()
 

--- a/tempfile_cli/commands/config.py
+++ b/tempfile_cli/commands/config.py
@@ -1,6 +1,7 @@
 from tempfile_cli.core.utils  import load_config, save_config
 
 def register(subparsers):
+    """Register the ``config`` subcommand for managing preferences."""
     parser = subparsers.add_parser("config", help="Get or set user preferences")
     parser.add_argument("action", choices=["get", "set"], help="Get or set a config value")
     parser.add_argument("key", help="The config key to access")
@@ -8,6 +9,7 @@ def register(subparsers):
     parser.set_defaults(handler=handle)
 
 def handle(args):
+    """Retrieve or update configuration values."""
     config = load_config()
 
     if args.action == "get":

--- a/tempfile_cli/commands/edit.py
+++ b/tempfile_cli/commands/edit.py
@@ -3,12 +3,13 @@ import subprocess
 from tempfile_cli.core.utils  import TEMPFILE_DIR
 
 def register(subparsers):
-    # Register the 'edit' subcommand
+    """Register the ``edit`` subcommand to open a tempfile."""
     parser = subparsers.add_parser("edit", help="Open an existing tempfile in your editor")
     parser.add_argument("name", help="Filename to edit (e.g. 2025-07-13_1834.txt)")
     parser.set_defaults(handler=handle)
 
 def handle(args):
+    """Open the specified tempfile in the user's editor."""
     file_path = TEMPFILE_DIR / args.name
 
     if not file_path.exists():

--- a/tempfile_cli/commands/keep.py
+++ b/tempfile_cli/commands/keep.py
@@ -10,12 +10,13 @@ from tempfile_cli.core.utils  import (
 KEEP_DIR = Path.home() / "Documents" / "tempfile_kept"
 
 def register(subparsers):
-    # Register the 'keep' subcommand
+    """Register the ``keep`` subcommand for archiving a tempfile."""
     parser = subparsers.add_parser("keep", help="Move file to permanent location")
     parser.add_argument("name", help="Name of the file to keep")
     parser.set_defaults(handler=handle)
 
 def handle(args):
+    """Move the given tempfile to a permanent location."""
     ensure_dir(KEEP_DIR)
     metadata = load_metadata()
 

--- a/tempfile_cli/commands/list.py
+++ b/tempfile_cli/commands/list.py
@@ -8,7 +8,7 @@ init(autoreset=True)
 
 # List all tempfiles with their metadata
 def register(subparsers):
-    # Register the 'list' subcommand
+    """Register the ``list`` subcommand to show stored tempfiles."""
     parser = subparsers.add_parser("list", help="List all tempfiles")
     parser.add_argument(
         "--tag",
@@ -18,6 +18,7 @@ def register(subparsers):
 
 # Handle the 'list' command
 def handle(args):
+    """Display stored tempfiles with optional tag filtering."""
     metadata = load_metadata()
     if not metadata:
         print("No tempfiles found.")

--- a/tempfile_cli/commands/new.py
+++ b/tempfile_cli/commands/new.py
@@ -10,7 +10,7 @@ default_days = int(config.get("default_days", 30))  # fallback = 30
 
 
 def register(subparsers):
-    # Register the 'new' subcommand
+    """Register the ``new`` subcommand for creating a tempfile."""
     parser = subparsers.add_parser("new", help="Create a new tempfile")
     parser.add_argument("name", nargs="?", help="Optional name for the file")
     parser.add_argument("--tag", action="append", help="Add one or more tags")
@@ -18,6 +18,7 @@ def register(subparsers):
 
 
 def handle(args):
+    """Create a new tempfile, record metadata and open it."""
    
 
     # Ensure the directory exists

--- a/tempfile_cli/commands/schedule.py
+++ b/tempfile_cli/commands/schedule.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 
 def register(subparsers):
+    """Register the ``schedule`` subcommand to install a cron job."""
     parser = subparsers.add_parser("schedule", help="Install a cron job for automatic cleaning")
     parser.set_defaults(handler=handle)
     parser.add_argument(
@@ -15,6 +16,7 @@ def register(subparsers):
     )
 
 def handle(args):
+    """Install a daily or weekly cron entry for automatic cleaning."""
     # Determine python executable and main.py path
     python_exec = sys.executable
     project_dir = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary
- document `register` and `handle` functions in each command module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6874cb66e7e083299aa8bc61e72b05db